### PR TITLE
Add versions.json release asset

### DIFF
--- a/.github/workflows/build-models.yml
+++ b/.github/workflows/build-models.yml
@@ -72,6 +72,17 @@ jobs:
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate versions.json
+        run: uv run dtai versions
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -85,3 +96,5 @@ jobs:
             echo "Uploading $(basename "$pkg")..."
             gh release upload "${{ github.event.release.tag_name }}" "$pkg" --repo "$GH_REPO"
           done
+          echo "Uploading versions.json..."
+          gh release upload "${{ github.event.release.tag_name }}" output/versions.json --repo "$GH_REPO"

--- a/darktable_ai/cli.py
+++ b/darktable_ai/cli.py
@@ -200,6 +200,26 @@ def list_models(ctx, as_json):
             click.echo(f"  {config.id:<35} {config.task:<15} {config.description}{status}")
 
 
+@main.command("versions")
+@click.pass_context
+def versions(ctx):
+    """Generate versions.json from model.yaml files."""
+    root = _get_root(ctx)
+    models = discover_models(root)
+    data = {
+        "models": {
+            m.id: m.version
+            for m in sorted(models, key=lambda m: m.id)
+            if not m.skip
+        }
+    }
+    output_path = root / "output" / "versions.json"
+    with open(output_path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    click.echo(f"Generated {output_path}")
+
+
 @main.command("eval")
 @click.argument("task")
 @click.argument("model_id")


### PR DESCRIPTION
- Add `dtai versions` CLI command that generates `output/versions.json` from `model.yaml` files, mapping each non-skipped model ID to its version string
- Update build workflow to generate and upload `versions.json` as a release asset alongside `.dtmodel` files
- darktable can fetch `versions.json` from the latest release to check for model updates without downloading full model packages
