### PR TITLE
Fix versions.json generation in CI

### DIFF
--- a/.github/workflows/check-models.yml
+++ b/.github/workflows/check-models.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Generate versions.json
+        run: uv run dtai versions
+
       - id: find
         name: Discover non-skipped models
         run: |

--- a/darktable_ai/cli.py
+++ b/darktable_ai/cli.py
@@ -214,6 +214,7 @@ def versions(ctx):
         }
     }
     output_path = root / "output" / "versions.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")


### PR DESCRIPTION
@TurboGit : This fixes broken CI.

- Fix `dtai versions` failing in CI due to missing `output/` directory
- Add `dtai versions` step to PR check workflow to catch similar issues early