### PR TITLE
Bump model opset to 20

### DIFF
--- a/models/embed-openclip-vitb32/convert.py
+++ b/models/embed-openclip-vitb32/convert.py
@@ -231,7 +231,7 @@ def generate_tags(model, tokenizer, output_path):
 # Main
 # ---------------------------------------------------------------------------
 
-def convert(output, tags_output, opset=17):
+def convert(output, tags_output, opset=20):
     """Entry point for programmatic conversion."""
     os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
 
@@ -257,7 +257,7 @@ def main():
     )
     parser.add_argument("--output", required=True, help="Output ONNX path")
     parser.add_argument("--tags-output", required=True, help="Output tags.json path")
-    parser.add_argument("--opset", type=int, default=17, help="ONNX opset version")
+    parser.add_argument("--opset", type=int, default=20, help="ONNX opset version")
     args = parser.parse_args()
 
     convert(args.output, args.tags_output, args.opset)

--- a/models/embed-openclip-vitb32/model.yaml
+++ b/models/embed-openclip-vitb32/model.yaml
@@ -22,4 +22,4 @@ convert:
     args:
       output: "{output}/model.onnx"
       tags_output: "{output}/tags.json"
-      opset: 17
+      opset: 20

--- a/models/mask-object-sam21-base-plus/model.yaml
+++ b/models/mask-object-sam21-base-plus/model.yaml
@@ -31,4 +31,4 @@ convert:
       model_cfg: "configs/sam2.1/sam2.1_hiera_b+.yaml"
       checkpoint: "{temp}/sam2.1_hiera_base_plus.pt"
       output_dir: "{output}"
-      opset: 17
+      opset: 20

--- a/models/mask-object-sam21-small/convert.py
+++ b/models/mask-object-sam21-small/convert.py
@@ -336,7 +336,7 @@ def verify_model(model_path, dummy_inputs, name):
     print(f"{name} has successfully been run with ONNXRuntime.")
 
 
-def convert(model_cfg, checkpoint, output_dir, opset=17):
+def convert(model_cfg, checkpoint, output_dir, opset=20):
     """Entry point for programmatic conversion."""
     os.makedirs(output_dir, exist_ok=True)
     encoder_path = os.path.join(output_dir, "encoder.onnx")
@@ -373,8 +373,8 @@ def main():
                         help="Path to the SAM 2.1 model checkpoint (.pt).")
     parser.add_argument("--output-dir", type=str, required=True,
                         help="Output directory for encoder.onnx and decoder.onnx.")
-    parser.add_argument("--opset", type=int, default=17,
-                        help="ONNX opset version (default: 17).")
+    parser.add_argument("--opset", type=int, default=20,
+                        help="ONNX opset version (default: 20).")
     args = parser.parse_args()
 
     convert(args.model_cfg, args.checkpoint, args.output_dir, opset=args.opset)

--- a/models/mask-object-sam21-small/model.yaml
+++ b/models/mask-object-sam21-small/model.yaml
@@ -31,4 +31,4 @@ convert:
       model_cfg: "configs/sam2.1/sam2.1_hiera_s.yaml"
       checkpoint: "{temp}/sam2.1_hiera_small.pt"
       output_dir: "{output}"
-      opset: 17
+      opset: 20

--- a/models/mask-object-sam21-tiny/model.yaml
+++ b/models/mask-object-sam21-tiny/model.yaml
@@ -31,4 +31,4 @@ convert:
       model_cfg: "configs/sam2.1/sam2.1_hiera_t.yaml"
       checkpoint: "{temp}/sam2.1_hiera_tiny.pt"
       output_dir: "{output}"
-      opset: 17
+      opset: 20

--- a/models/mask-object-segnext-b2hq/convert.py
+++ b/models/mask-object-segnext-b2hq/convert.py
@@ -50,8 +50,8 @@ parser.add_argument(
     help="Output directory for encoder.onnx and decoder.onnx.",
 )
 parser.add_argument(
-    "--opset", type=int, default=17,
-    help="ONNX opset version (default: 17).",
+    "--opset", type=int, default=20,
+    help="ONNX opset version (default: 20).",
 )
 
 
@@ -341,7 +341,7 @@ def run_decoder_export(model, output, opset, image_feats):
 # Main
 # ---------------------------------------------------------------------------
 
-def convert(checkpoint, output_dir, opset=17):
+def convert(checkpoint, output_dir, opset=20):
     """Entry point for programmatic conversion."""
     os.makedirs(output_dir, exist_ok=True)
     encoder_path = os.path.join(output_dir, "encoder.onnx")

--- a/models/mask-object-segnext-b2hq/model.yaml
+++ b/models/mask-object-segnext-b2hq/model.yaml
@@ -30,3 +30,4 @@ convert:
     args:
       checkpoint: "{temp}/vitb_sa2_cocolvis_hq44k_epoch_0.pth"
       output_dir: "{output}"
+      opset: 20


### PR DESCRIPTION
Aligns export opset with the darktable runtime's minimum ORT API (1.18, opset 20 ceiling).

### Changed

- `embed-openclip-vitb32` – convert.py default + CLI + model.yaml.
- `mask-object-sam21-{small,base-plus,tiny}` – shared convert.py default + CLI, all three model.yaml files.
- `mask-object-segnext-b2hq` – convert.py default + CLI + model.yaml.

NR models (`denoise-nind`, `denoise-nafnet`, `rawdenoise-nind`, `upscale-bsrgan`) are changed in PR #22.