### PR TITLE
Reset all model versions to 0.1

### DIFF
--- a/models/denoise-nafnet/model.yaml
+++ b/models/denoise-nafnet/model.yaml
@@ -2,7 +2,7 @@ id: denoise-nafnet
 name: "denoise nafnet small"
 description: "NAFNet denoiser trained on SIDD dataset"
 task: denoise
-version: "1.0"
+version: "0.1"
 arch: nafnet
 backend: onnx
 tiling: true

--- a/models/denoise-nind/model.yaml
+++ b/models/denoise-nind/model.yaml
@@ -2,7 +2,7 @@ id: denoise-nind
 name: "denoise nind"
 description: "UNet denoiser trained on NIND dataset"
 task: denoise
-version: "1.0"
+version: "0.1"
 backend: onnx
 tiling: true
 type: single

--- a/models/embed-openclip-vitb32/model.yaml
+++ b/models/embed-openclip-vitb32/model.yaml
@@ -2,7 +2,7 @@ id: embed-openclip-vitb32
 name: "embed openclip vitb32"
 description: "OpenCLIP ViT-B-32 image embeddings for tagging and similarity"
 task: embed
-version: "1.0"
+version: "0.1"
 type: single
 dep_group: openclip
 

--- a/models/mask-object-sam21-base-plus/model.yaml
+++ b/models/mask-object-sam21-base-plus/model.yaml
@@ -2,7 +2,7 @@ id: mask-object-sam21-base-plus
 name: "mask sam2.1 hiera base plus"
 description: "Segment Anything 2.1 (Hiera Base Plus) for interactive masking"
 task: mask
-version: "1.0"
+version: "0.1"
 arch: sam2
 type: split
 dep_group: sam21

--- a/models/mask-object-sam21-small/model.yaml
+++ b/models/mask-object-sam21-small/model.yaml
@@ -2,7 +2,7 @@ id: mask-object-sam21-small
 name: "mask sam2.1 hiera small"
 description: "Segment Anything 2.1 (Hiera Small) for interactive masking"
 task: mask
-version: "1.0"
+version: "0.1"
 arch: sam2
 type: split
 dep_group: sam21

--- a/models/mask-object-sam21-tiny/model.yaml
+++ b/models/mask-object-sam21-tiny/model.yaml
@@ -2,7 +2,7 @@ id: mask-object-sam21-tiny
 name: "mask sam2.1 hiera tiny"
 description: "Segment Anything 2.1 (Hiera Tiny) for interactive masking"
 task: mask
-version: "1.0"
+version: "0.1"
 arch: sam2
 type: split
 dep_group: sam21

--- a/models/mask-object-segnext-b2hq/model.yaml
+++ b/models/mask-object-segnext-b2hq/model.yaml
@@ -2,7 +2,7 @@ id: mask-object-segnext-b2hq
 name: "mask segnext vitb-sax2 hq"
 description: "SegNext ViT-B SAx2 HQ fine-tuned for interactive masking"
 task: mask
-version: "1.0"
+version: "0.1"
 arch: segnext
 type: split
 dep_group: segnext

--- a/models/rawdenoise-nind/model.yaml
+++ b/models/rawdenoise-nind/model.yaml
@@ -2,7 +2,7 @@ id: rawdenoise-nind
 name: "raw denoise nind"
 description: "UtNet2 raw denoiser trained on RawNIND (Bayer + linear Rec.2020 variants)"
 task: rawdenoise
-version: "1.0"
+version: "0.1"
 arch: utnet2
 backend: onnx
 tiling: true

--- a/models/upscale-bsrgan/model.yaml
+++ b/models/upscale-bsrgan/model.yaml
@@ -2,7 +2,7 @@ id: upscale-bsrgan
 name: "upscale bsrgan"
 description: "BSRGAN 2x and 4x blind super-resolution"
 task: upscale
-version: "1.0"
+version: "0.1"
 backend: onnx
 tiling: true
 type: multi


### PR DESCRIPTION
Reset all models version to `0.1` so the nightly model channel can be tested against nightly darktable. The versions will be bumped back to `1.0` at release.