### PR TITLE
Opt small denoise CNNs into CoreML MLProgram format

### DIFF
--- a/darktable_ai/config.py
+++ b/darktable_ai/config.py
@@ -47,6 +47,7 @@ class ModelConfig:
     model_card: dict[str, str] = field(default_factory=dict)
     attributes: dict = field(default_factory=dict)
     cpu_only: list | dict | None = None
+    coreml_format: str | dict | None = None
 
     repo: RepoConfig | None = None
     checkpoints: list[Checkpoint] = field(default_factory=list)
@@ -122,6 +123,7 @@ def load_model_config(model_dir: Path, root_dir: Path) -> ModelConfig:
         model_card=data.get("model_card", {}),
         attributes=data.get("attributes", {}),
         cpu_only=data.get("cpu_only"),
+        coreml_format=data.get("coreml_format"),
         skip=skip,
         repo=repo,
         checkpoints=checkpoints,

--- a/darktable_ai/convert.py
+++ b/darktable_ai/convert.py
@@ -55,6 +55,9 @@ def generate_config_json(config: ModelConfig) -> None:
     if config.cpu_only is not None:
         data["cpu_only"] = config.cpu_only
 
+    if config.coreml_format is not None:
+        data["coreml_format"] = config.coreml_format
+
     config_file.write_text(json.dumps(data, indent=4, ensure_ascii=False) + "\n")
     print(f"  Generated: {config_file}")
 

--- a/models/denoise-nafnet/model.yaml
+++ b/models/denoise-nafnet/model.yaml
@@ -2,12 +2,13 @@ id: denoise-nafnet
 name: "denoise nafnet small"
 description: "NAFNet denoiser trained on SIDD dataset"
 task: denoise
-version: "1.0"
+version: "0.2"
 arch: nafnet
 backend: onnx
 tiling: true
 type: single
 dep_group: nafnet
+coreml_format: mlprogram
 
 attributes:
   input_sizes: [768]

--- a/models/denoise-nind/model.yaml
+++ b/models/denoise-nind/model.yaml
@@ -2,11 +2,12 @@ id: denoise-nind
 name: "denoise nind"
 description: "UNet denoiser trained on NIND dataset"
 task: denoise
-version: "1.0"
+version: "0.2"
 backend: onnx
 tiling: true
 type: single
 dep_group: nind
+coreml_format: mlprogram
 
 attributes:
   input_sizes: [768]

--- a/models/rawdenoise-nind/model.yaml
+++ b/models/rawdenoise-nind/model.yaml
@@ -2,14 +2,13 @@ id: rawdenoise-nind
 name: "raw denoise nind"
 description: "UtNet2 raw denoiser trained on RawNIND (Bayer + linear Rec.2020 variants)"
 task: rawdenoise
-version: "1.0"
+version: "0.2"
 arch: utnet2
 backend: onnx
 tiling: true
 type: multi
 dep_group: rawnind
-cpu_only:
-  model_bayer: [coreml]
+coreml_format: mlprogram
 
 attributes:
   input_sizes: [512]


### PR DESCRIPTION
Paired with the darktable-side `coreml_format` parsing + V2 CoreML EP with persistent compile cache.

Adds a `coreml_format` field to model manifests. Two values: `neuralnetwork` (default – Apple's historical default, fast cold compile, sub-second warm load) and `mlprogram` (13-34% faster inference on simple CNNs, but heavier compile and weaker op coverage for transformers).

Benchmarked on macOS arm64:

- Small CNNs (NIND, NAFNet) – clear MLProgram win.
- Transformers / BSRGAN – dramatically slower on MLProgram (SAM encoder 44 s vs 6 s cold). Stay on NeuralNetwork.

This PR adds the plumbing and opts in the three winning models. Everything else keeps the default.