### PR TITLE
Prepare model repo for API-free discovery and verified downloads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,12 +127,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate versions.json
-        run: uv run dtai versions
-
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
+
+      - name: Generate versions.json (with SHAs)
+        run: uv run dtai versions --artifacts-dir artifacts
 
       # delete all nightly-* releases so the next publish creates a
       # fresh one with a new created_at — keeps it at the top of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Generate versions.json
-        run: uv run dtai versions
-
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
+
+      - name: Generate versions.json (with SHAs)
+        run: uv run dtai versions --artifacts-dir artifacts
 
       - name: Resolve version from tag
         id: ver

--- a/darktable_ai/cli.py
+++ b/darktable_ai/cli.py
@@ -201,18 +201,52 @@ def list_models(ctx, as_json):
 
 
 @main.command("versions")
+@click.option(
+    "--artifacts-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Directory containing built .dtmodel artifacts; if provided, "
+    "SHA256 digests for each model are included in the output. "
+    "Accepts both <artifacts-dir>/<id>/<id>.dtmodel (CI layout from "
+    "actions/download-artifact) and the flat <artifacts-dir>/<id>.dtmodel "
+    "layout (local `dtai package` output).",
+)
 @click.pass_context
-def versions(ctx):
-    """Generate versions.json from model.yaml files."""
+def versions(ctx, artifacts_dir):
+    """Generate versions.json from model.yaml files.
+
+    When --artifacts-dir is provided, the output additionally carries a
+    top-level "sha256" object mapping model id to "sha256:HEX". The
+    consumer (darktable) reads this and skips a per-asset GitHub API call
+    that would otherwise cost one rate-limited request per downloaded
+    model.
+    """
+    import hashlib
+
     root = _get_root(ctx)
-    models = discover_models(root)
-    data = {
-        "models": {
-            m.id: m.version
-            for m in sorted(models, key=lambda m: m.id)
-            if not m.skip
-        }
-    }
+    models = [m for m in discover_models(root) if not m.skip]
+    models.sort(key=lambda m: m.id)
+
+    entries: dict[str, dict] = {m.id: {"version": m.version} for m in models}
+
+    if artifacts_dir is not None:
+        for m in models:
+            # accept both nested (CI: actions/download-artifact) and flat
+            # (local: `dtai package` output) layouts
+            nested = artifacts_dir / m.id / f"{m.id}.dtmodel"
+            flat = artifacts_dir / f"{m.id}.dtmodel"
+            path = nested if nested.is_file() else flat
+            if not path.is_file():
+                click.echo(f"Warning: artifact missing for {m.id}: {nested} or {flat}", err=True)
+                continue
+            h = hashlib.sha256()
+            with open(path, "rb") as fh:
+                for chunk in iter(lambda: fh.read(1 << 20), b""):
+                    h.update(chunk)
+            entries[m.id]["sha256"] = f"sha256:{h.hexdigest()}"
+
+    data = {"models": entries}
+
     output_path = root / "output" / "versions.json"
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as f:

--- a/releases-index.json
+++ b/releases-index.json
@@ -1,0 +1,7 @@
+{
+  "schema": 1,
+  "compatible_releases": {
+    "5.5.0": "nightly-5.5.0",
+    "5.6.0": "release-5.6.0.1"
+  }
+}


### PR DESCRIPTION
Two changes that let darktable discover and download models without touching `api.github.com` (and so without being subject to its 60 req/hr unauthenticated rate limit – breaks users behind shared NAT, in CI, in classrooms).

- **`releases-index.json`** (new, tracked at repo root): maps darktable `X.Y.Z` to the model-release tag built for it. darktable reads it from `raw.githubusercontent.com/.../HEAD/releases-index.json` (CDN, branch-agnostic via `HEAD`, no API limit). `schema: 1` shape is frozen forever so old binaries keep working; future schemas live in parallel keys.
- **`versions.json` carries SHA256 per model.** `dtai versions` gained `--artifacts-dir`; when CI passes the built `.dtmodel` dir, the manifest gains a nested `models[id] = {version, sha256}` shape. darktable reads the SHA from there instead of an API call per asset. CLI accepts both nested (CI) and flat (local `output/`) layouts. Both `release.yml` and `nightly.yml` updated to download artifacts before generating the manifest.

## Breaking change

`models[id]` went from string → object. Old darktable installs silently stop detecting model updates until they upgrade. No crash; matching darktable C-side PR ships separately.