### PR TITLE
Fix opencv variant collision and PyTorch 2.6 torch.load

### DIFF
--- a/models/denoise-nafnet/convert.py
+++ b/models/denoise-nafnet/convert.py
@@ -49,7 +49,10 @@ def load_nafnet_model(config_path, checkpoint_path):
         dec_blk_nums=network_g.get('dec_blk_nums', [2, 2, 2, 2])
     )
 
-    checkpoint = torch.load(checkpoint_path, map_location='cpu')
+    # weights_only=False: PyTorch 2.6 flipped this default to True, which
+    # rejects the NAFNet checkpoint (it pickles non-tensor objects). The
+    # checkpoint is a trusted file we ship, so full unpickling is safe.
+    checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
     if 'params' in checkpoint:
         state_dict = checkpoint['params']
     elif 'params_ema' in checkpoint:

--- a/models/mask-object-segnext-b2hq/convert.py
+++ b/models/mask-object-segnext-b2hq/convert.py
@@ -217,7 +217,10 @@ def to_numpy(tensor):
 
 def load_segnext_model(checkpoint_path):
     """Load SegNext model from checkpoint."""
-    state_dict = torch.load(checkpoint_path, map_location="cpu")
+    # weights_only=False: checkpoint stores a non-tensor "config" object
+    # alongside the weights, which PyTorch 2.6's weights_only=True default
+    # rejects. Trusted file we ship, so full unpickling is safe.
+    state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
     model = load_model(state_dict["config"])
     model.load_state_dict(state_dict["state_dict"], strict=True)
     for param in model.parameters():

--- a/models/upscale-bsrgan/convert.py
+++ b/models/upscale-bsrgan/convert.py
@@ -154,7 +154,10 @@ def convert(checkpoint, output, scale, height=256, width=256,
 
     print(f"Loading BSRGAN model (scale={scale})...")
     model = RRDBNet(in_nc=3, out_nc=3, nf=64, nb=23, gc=32, sf=scale)
-    state_dict = torch.load(checkpoint, map_location='cpu')
+    # weights_only=False for consistency with the other converters; this
+    # is a trusted checkpoint we ship. PyTorch 2.6 made weights_only=True
+    # the default, which can reject checkpoints carrying non-tensor data.
+    state_dict = torch.load(checkpoint, map_location='cpu', weights_only=False)
     model.load_state_dict(state_dict, strict=True)
     model.eval()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,12 @@ core = [
     "onnx>=1.10.0",
     "onnxruntime",
     "onnxsim",
-    "opencv-python",
+    # headless, not opencv-python: albumentations/albucore pull
+    # opencv-python-headless, and both variants install into the same
+    # cv2/ namespace. Two of them race over cv2/__init__.py and CI ends
+    # up with a half-written package (cv2.imread missing). We use no GUI
+    # calls, so headless is the single consistent variant.
+    "opencv-python-headless",
 ]
 nafnet = [
     {include-group = "core"},
@@ -86,6 +91,15 @@ eval = [
     "Pillow",
     "scipy",
 ]
+
+[tool.uv]
+# mmcv/mmengine require opencv-python while albumentations/albucore
+# require opencv-python-headless; both install into the same cv2/
+# namespace and race over cv2/__init__.py, leaving a half-written
+# package on CI (cv2.imread missing). Force the headless variant
+# everywhere — mmcv imports cv2 too and we use no GUI calls — so the
+# shared venv only ever has one opencv.
+override-dependencies = ["opencv-python; sys_platform == 'never'"]
 
 [tool.uv.extra-build-dependencies]
 mmcv = ["setuptools<71"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
+[manifest]
+overrides = [{ name = "opencv-python", marker = "sys_platform == 'never'" }]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -267,7 +270,7 @@ all-models = [
     { name = "onnxscript" },
     { name = "onnxsim" },
     { name = "open-clip-torch" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
     { name = "rawpy" },
@@ -287,7 +290,7 @@ bsrgan = [
     { name = "onnx" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -296,7 +299,7 @@ core = [
     { name = "onnx" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -315,7 +318,7 @@ nafnet = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "requests" },
     { name = "scikit-image" },
     { name = "scipy" },
@@ -331,7 +334,7 @@ nind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -342,7 +345,7 @@ openclip = [
     { name = "onnxscript" },
     { name = "onnxsim" },
     { name = "open-clip-torch" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -354,7 +357,7 @@ rawnind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
     { name = "rawpy" },
@@ -369,7 +372,7 @@ sam21 = [
     { name = "onnx" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
 ]
@@ -381,7 +384,7 @@ segnext = [
     { name = "onnx" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "setuptools" },
     { name = "torch" },
     { name = "torchvision" },
@@ -412,7 +415,7 @@ all-models = [
     { name = "onnxscript" },
     { name = "onnxsim" },
     { name = "open-clip-torch" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
     { name = "rawpy" },
@@ -433,7 +436,7 @@ bsrgan = [
     { name = "onnx", specifier = ">=1.10.0" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
 ]
@@ -442,7 +445,7 @@ core = [
     { name = "onnx", specifier = ">=1.10.0" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
 ]
@@ -461,7 +464,7 @@ nafnet = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "requests" },
     { name = "scikit-image" },
     { name = "scipy" },
@@ -477,7 +480,7 @@ nind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
 ]
@@ -488,7 +491,7 @@ openclip = [
     { name = "onnxscript" },
     { name = "onnxsim" },
     { name = "open-clip-torch" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
 ]
@@ -500,7 +503,7 @@ rawnind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
     { name = "rawpy" },
@@ -515,7 +518,7 @@ sam21 = [
     { name = "onnx", specifier = ">=1.10.0" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torch", specifier = ">=2.5.1" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
@@ -528,7 +531,7 @@ segnext = [
     { name = "onnx", specifier = ">=1.10.0" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "setuptools" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
@@ -982,7 +985,7 @@ dependencies = [
     { name = "addict" },
     { name = "mmengine" },
     { name = "numpy" },
-    { name = "opencv-python" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyyaml" },
@@ -999,7 +1002,7 @@ dependencies = [
     { name = "addict" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "opencv-python" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
     { name = "pyyaml" },
     { name = "regex", marker = "sys_platform == 'win32'" },
     { name = "rich" },
@@ -1321,17 +1324,9 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/4d/53b30a2a3ac1f75f65a59eb29cf2ee7207ce64867db47036ad61743d5a23/opencv_python-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:432f67c223f1dc2824f5e73cdfcd9db0efc8710647d4e813012195dc9122a52a", size = 37326322, upload-time = "2025-01-16T13:52:25.887Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/84/0a67490741867eacdfa37bc18df96e08a9d579583b419010d7f3da8ff503/opencv_python-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:9d05ef13d23fe97f575153558653e2d6e87103995d54e6a35db3f282fe1f9c66", size = 56723197, upload-time = "2025-01-16T13:55:21.222Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/bd/29c126788da65c1fb2b5fb621b7fed0ed5f9122aa22a0868c5e2c15c6d23/opencv_python-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b92ae2c8852208817e6776ba1ea0d6b1e0a1b5431e971a2a0ddd2a8cc398202", size = 42230439, upload-time = "2025-01-16T13:51:35.822Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/8b/90eb44a40476fa0e71e05a0283947cfd74a5d36121a11d926ad6f3193cc4/opencv_python-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b02611523803495003bd87362db3e1d2a0454a6a63025dc6658a9830570aa0d", size = 62986597, upload-time = "2025-01-16T13:52:08.836Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d7/1d5941a9dde095468b288d989ff6539dd69cd429dbf1b9e839013d21b6f0/opencv_python-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:810549cb2a4aedaa84ad9a1c92fbfdfc14090e2749cedf2c1589ad8359aa169b", size = 29384337, upload-time = "2025-01-16T13:52:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/f1c30a92854540bf789e9cd5dde7ef49bbe63f855b85a2e6b3db8135c591/opencv_python-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:085ad9b77c18853ea66283e98affefe2de8cc4c1f43eda4c100cf9b2721142ec", size = 39488044, upload-time = "2025-01-16T13:52:21.928Z" },
-]
 
 [[package]]
 name = "opencv-python-headless"


### PR DESCRIPTION
Two CI failures in the conversion pipeline, both blocking the NAFNet job.

**opencv collision** - `mmcv` pulls `opencv-python`, `albumentations` pulls `opencv-python-headless`; both own the `cv2/` namespace and race in the shared venv, leaving a half-written `cv2` (no `imread`) that corrupts every group. Fix: standardize on headless (`core` requires it, an `override-dependencies` entry drops `opencv-python`). We make no GUI calls, and `mmcv` works with headless.

**PyTorch 2.6 torch.load** - 2.6 flipped `weights_only` to `True` by default, which rejects our checkpoints (they carry non-tensor config/metadata). Fix: pass `weights_only=False` in the NAFNet/SegNext/BSRGAN converters - trusted files we ship. Also re-enables `denoise-nafnet` (drops `.skip`).

**Note:** if CI caches `.venv` or the uv cache, bust it once - a cached env still has the corrupted `cv2/` and `uv sync` won't repair an already-present package.