### PR TITLE
Bump model versions to 1.0 for release

### DIFF
--- a/models/denoise-nafnet/model.yaml
+++ b/models/denoise-nafnet/model.yaml
@@ -2,7 +2,7 @@ id: denoise-nafnet
 name: "denoise nafnet small"
 description: "NAFNet denoiser trained on SIDD dataset"
 task: denoise
-version: "0.2"
+version: "1.0"
 arch: nafnet
 backend: onnx
 tiling: true

--- a/models/denoise-nind/model.yaml
+++ b/models/denoise-nind/model.yaml
@@ -2,7 +2,8 @@ id: denoise-nind
 name: "denoise nind"
 description: "UNet denoiser trained on NIND dataset"
 task: denoise
-version: "0.2"
+version: "1.0"
+arch: unet
 backend: onnx
 tiling: true
 type: single

--- a/models/mask-object-sam21-base-plus/model.yaml
+++ b/models/mask-object-sam21-base-plus/model.yaml
@@ -2,8 +2,9 @@ id: mask-object-sam21-base-plus
 name: "mask sam2.1 hiera base plus"
 description: "Segment Anything 2.1 (Hiera Base Plus) for interactive masking"
 task: mask
-version: "0.1"
+version: "1.0"
 arch: sam2
+backend: onnx
 type: split
 dep_group: sam21
 

--- a/models/mask-object-sam21-small/model.yaml
+++ b/models/mask-object-sam21-small/model.yaml
@@ -2,8 +2,9 @@ id: mask-object-sam21-small
 name: "mask sam2.1 hiera small"
 description: "Segment Anything 2.1 (Hiera Small) for interactive masking"
 task: mask
-version: "0.1"
+version: "1.0"
 arch: sam2
+backend: onnx
 type: split
 dep_group: sam21
 

--- a/models/mask-object-sam21-tiny/model.yaml
+++ b/models/mask-object-sam21-tiny/model.yaml
@@ -2,8 +2,9 @@ id: mask-object-sam21-tiny
 name: "mask sam2.1 hiera tiny"
 description: "Segment Anything 2.1 (Hiera Tiny) for interactive masking"
 task: mask
-version: "0.1"
+version: "1.0"
 arch: sam2
+backend: onnx
 type: split
 dep_group: sam21
 

--- a/models/mask-object-segnext-b2hq/model.yaml
+++ b/models/mask-object-segnext-b2hq/model.yaml
@@ -2,8 +2,9 @@ id: mask-object-segnext-b2hq
 name: "mask segnext vitb-sax2 hq"
 description: "SegNext ViT-B SAx2 HQ fine-tuned for interactive masking"
 task: mask
-version: "0.1"
+version: "1.0"
 arch: segnext
+backend: onnx
 type: split
 dep_group: segnext
 

--- a/models/rawdenoise-nind/model.yaml
+++ b/models/rawdenoise-nind/model.yaml
@@ -2,7 +2,7 @@ id: rawdenoise-nind
 name: "raw denoise nind"
 description: "UtNet2 raw denoiser trained on RawNIND (Bayer + linear Rec.2020 variants)"
 task: rawdenoise
-version: "0.2"
+version: "1.0"
 arch: utnet2
 backend: onnx
 tiling: true

--- a/models/upscale-bsrgan/model.yaml
+++ b/models/upscale-bsrgan/model.yaml
@@ -2,7 +2,8 @@ id: upscale-bsrgan
 name: "upscale bsrgan"
 description: "BSRGAN 2x and 4x blind super-resolution"
 task: upscale
-version: "0.2"
+version: "1.0"
+arch: bsrgan
 backend: onnx
 tiling: true
 type: multi

--- a/models/upscale-realplksr/model.yaml
+++ b/models/upscale-realplksr/model.yaml
@@ -2,7 +2,8 @@ id: upscale-realplksr
 name: "upscale realplksr"
 description: "RealPLKSR 2x and 4x super-resolution, robust to typical photo artefacts (noise, blur, compression)"
 task: upscale
-version: "0.2"
+version: "1.0"
+arch: plksr
 backend: onnx
 tiling: true
 type: multi


### PR DESCRIPTION
Bump all model versions to `1.0` for the upcoming darktable release. Also fill in a few optional `model.yaml` fields with their default values where they were missing, just for consistency across the catalog.

No functional changes - metadata only, no model weights touched.