### PR TITLE
Fix release 5.6.0 mapping

### DIFF
--- a/releases-index.json
+++ b/releases-index.json
@@ -2,6 +2,6 @@
   "schema": 1,
   "compatible_releases": {
     "5.5.0": "nightly-5.5.0",
-    "5.6.0": "release-5.6.0.1"
+    "5.6.0": "release-5.6.0"
   }
 }


### PR DESCRIPTION
Small fix in releases index for upcoming release. We will start with `release-5.6.0` for models.