### PR TITLE
Prepare repo for the 5.7 dev cycle

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -3,6 +3,12 @@ name: Check Models PR
 on:
   pull_request:
     branches: [master, 'models-*.x']
+    paths-ignore:
+      - "tools/**"
+      - "**.md"
+      - "releases-index.json"
+      - ".github/workflows/nightly.yml"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 # one check per PR; new pushes cancel the previous run

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,32 +1,14 @@
-We're pleased to announce the first release of the darktable AI models, 5.6.0!
+We're pleased to announce the first release of the darktable AI models, 5.8.0!
 
-The github release is here: [https://github.com/darktable-org/darktable-ai/releases/tag/release-5.6.0](https://github.com/darktable-org/darktable-ai/releases/tag/release-5.6.0).
+The github release is here: [https://github.com/darktable-org/darktable-ai/releases/tag/release-5.8.0](https://github.com/darktable-org/darktable-ai/releases/tag/release-5.8.0).
 
-These models are intended for darktable 5.6.0 and later. They power the AI features introduced in this darktable release – interactive object masking and neural restore (raw denoise, image denoise, upscale). Models are installed and managed from the AI tab in darktable's preferences.
+These models are intended for darktable 5.8.0 and later.
 
 ## Models
 
-### Object masking – used in the darkroom mask manager's AI object tool
-
-- **mask sam2.1 hiera small** (`mask-object-sam21-small`) – Segment Anything 2.1 (Hiera Small). Click on an object to generate a precise mask; click again with foreground/background prompt points to refine. Encoder + decoder pair: the encoder runs once per image (with optional GPU acceleration), the lightweight decoder produces masks interactively. Default choice for most users.
-
-- **mask sam2.1 hiera tiny / base plus** (`mask-object-sam21-tiny`, `mask-object-sam21-base-plus`) – lighter and heavier variants of the same SAM 2.1 pipeline. Use *tiny* on low-memory systems or for faster encoder runs; use *base plus* when *small* doesn't capture an object cleanly.
-
-- **mask segnext vitb-sax2 hq** (`mask-object-segnext-b2hq`) – SegNext ViT-B SAx2 HQ fine-tuned for interactive masking. Alternative to SAM 2.1 with openly documented training data. Also useful when SAM 2.1's segmentation behaviour doesn't fit a particular scene.
-
-### Neural restore – used in the neural restore module in the lighttable/darkroom sidebar
-
-- **denoise nind** (`denoise-nind`) – UNet denoiser from the NIND (Natural Image Noise Dataset) project, trained on Wikimedia Commons noisy/clean pairs. Drives the module's *denoise* task on demosaiced RGB.
-
-- **denoise nafnet small** (`denoise-nafnet`) – lightweight NAFNet denoiser trained on the SIDD smartphone dataset. Alternative *denoise* task model – tuned for noise patterns typical of small-sensor cameras.
-
-- **raw denoise nind** (`rawdenoise-nind`) – UtNet2 raw-domain denoiser trained on RawNIND. Bundles two variants in one package: a Bayer model that denoises and demosaics in one step (pre-demosaic input), and a linear Rec.2020 model used for non-Bayer sensors (X-Trans, Foveon, 4-colour CFAs). Drives the module's *raw denoise* task.
-
-- **upscale realplksr** (`upscale-realplksr`) – RealPLKSR (Partial Large Kernel CNN) at 2× and 4×. Faithful upscaling that preserves detail without smoothing or inventing texture. Best for clean sources like edited RAW exports or high-quality scans. Drives the module's *upscale* task.
-
-- **upscale bsrgan** (`upscale-bsrgan`) – BSRGAN blind super-resolution at 2× and 4×. Combines upscaling with implicit denoising/deblurring, useful when the source already has visible noise or compression artefacts. Drives the module's *upscale* task.
+N/A
 
 ## Compatibility
 
-- Darktable version: 5.6.0.
+- Darktable version: 5.8.0.
 - All models are statically-shaped ONNX with tile sizes declared in the manifest. Tiles are sized for both CPU inference and the GPU execution providers supported by darktable (CUDA, ROCm/MIGraphX, DirectML, OpenVINO, CoreML).

--- a/releases-index.json
+++ b/releases-index.json
@@ -2,6 +2,7 @@
   "schema": 1,
   "compatible_releases": {
     "5.5.0": "nightly-5.5.0",
-    "5.6.0": "release-5.6.0"
+    "5.6.0": "release-5.6.0",
+    "5.7.0": "nightly-5.7.0"
   }
 }


### PR DESCRIPTION
Now that `release-5.6.0` is cut and `models-5.6.x` is branched, master moves on to 5.7 dev work. Two small bookkeeping changes to make that smoother:

- `RELEASE_NOTES.md`: reset to a 5.8.0 placeholder so the file isn't carrying the 5.6.0 announcement through dev.
- `releases-index.json`: map `5.7.0` to `nightly-5.7.0` so darktable nightlies can resolve their model set during the cycle.

Also unrelated but bundled-in CI cleanup:

- `.github/workflows/check-pr.yml`: add `paths-ignore` so docs-only, `tools/`-only, `releases-index.json`-only, and `nightly.yml` / `release.yml`-only PRs no longer trigger the full model validation matrix. Saves several minutes per cosmetic change.