### PR TITLE
Add embed-openclip-rn101-yfcc15m model (FP16, 86-tag default vocab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently targets the ONNX backend. The pipeline is designed to support addition
 |-------------------------------------------------------------------------------|---------|-------------------------------------------------|
 | [`denoise-nafnet`](models/denoise-nafnet/README.md)                           | denoise | NAFNet denoiser trained on SIDD dataset         |
 | [`denoise-nind`](models/denoise-nind/README.md)                               | denoise | UNet denoiser trained on NIND dataset           |
+| [`embed-openclip-rn101-yfcc15m`](models/embed-openclip-rn101-yfcc15m/README.md) | embed   | OpenCLIP RN101 trained on Flickr CC photos (YFCC15M) |
 | [`mask-object-sam21-base-plus`](models/mask-object-sam21-base-plus/README.md) | mask    | SAM 2.1 Hiera Base Plus for interactive masking |
 | [`mask-object-sam21-small`](models/mask-object-sam21-small/README.md)         | mask    | SAM 2.1 Hiera Small for interactive masking     |
 | [`mask-object-sam21-tiny`](models/mask-object-sam21-tiny/README.md)           | mask    | SAM 2.1 Hiera Tiny for interactive masking      |

--- a/models/embed-openclip-rn101-yfcc15m/README.md
+++ b/models/embed-openclip-rn101-yfcc15m/README.md
@@ -1,0 +1,96 @@
+# OpenCLIP RN101 (YFCC15M)
+
+ResNet-101 image embedder from the OpenCLIP project, trained on YFCC15M –
+15 million Flickr photos with Creative Commons licences. Produces
+512-dimensional embeddings used in darktable for centroid-based tag
+suggestion and image-similarity search.
+
+## Source
+
+- Architecture & weights: [mlfoundations/open_clip](https://github.com/mlfoundations/open_clip), `RN101 / yfcc15m`
+- License: MIT
+- Paper: [Reproducible scaling laws for contrastive language-image learning](https://arxiv.org/abs/2212.07143)
+- Training data: [YFCC15M](https://www.researchgate.net/publication/270275998_The_New_Data_and_New_Challenges_in_Multimedia_Research_-_YFCC100M_The_New_Data_and_New_Challenges_in_Multimedia_Research) (Thomee et al.) – subset of YFCC100M curated by Radford et al. for CLIP training
+
+## Why this model
+
+YFCC15M is the only widely-available CLIP training dataset where every image
+was opt-in licensed by its author (Flickr Creative Commons). Other CLIP-family
+training corpora (LAION, WebLI, OpenAI's WIT-400M, DataComp, MetaCLIP) are
+all web scrapes without per-image consent. For darktable's open-source
+compliance criteria – *"Models trained on undisclosed or scraped personal
+data without consent are not accepted"* – YFCC15M is the right fit.
+
+The trade-off: ~31% ImageNet zero-shot top-1, vs ~67% for LAION-trained
+ViT-B-32 or ~76% for SigLIP 2. For darktable's actual use case (photo-domain
+centroid matching against a user's library) the gap is narrower than the
+benchmark suggests, because YFCC's training distribution is photo-aligned
+rather than the everything-on-the-web mix that boosts LAION's ImageNet score.
+
+## How it's used in darktable
+
+Two cooperating workflows:
+
+- **Per-user tag taxonomy.** Average image embeddings per user-applied tag
+  → centroid in 512-dim space. Suggest the same tag on new images whose
+  embedding is close to that centroid.
+- **Cold-start defaults.** For users without enough examples of their own,
+  fall back to 86 precomputed centroids covering common photographic
+  concepts (see [`tags.md`](tags.md)). Hierarchical names use darktable's
+  `|` separator: `genre|landscape`, `subject|animal|dog`,
+  `lighting|golden hour`, etc.
+
+The text encoder is run *only at convert time* to bake those centroids
+into `tags.json`. At runtime, darktable runs only the image encoder.
+
+## Architecture
+
+| Property | Value |
+| -------- | ----- |
+| Visual backbone | Modified ResNet-101 (CLIP variant: anti-aliased pooling, attention pool head) |
+| Input | 224×224 RGB, normalised with OpenAI CLIP stats (mean 0.485 / 0.458 / 0.408, std 0.269 / 0.261 / 0.276) |
+| Embedding dim | 512 |
+| Parameters | ~130M |
+
+## ONNX Assets
+
+| File         | Purpose                                                                  | Size          |
+|--------------|--------------------------------------------------------------------------|---------------|
+| `model.onnx` | image → 512-dim L2-normalised embedding (mean/std subtraction baked in)  | ~60 MB (FP16) |
+| `tags.json`  | precomputed 512-dim centroids for the 86-tag default taxonomy            | ~270 KB       |
+
+The convert wrapper bakes mean/std subtraction and L2 normalisation into the
+ONNX graph so the caller only needs to feed `[0, 1]` RGB pixels.
+
+The visual backbone runs in FP16; the graph's input and output stay
+FP32 because the casts happen inside the export wrapper (after mean/std
+subtraction on the input, before L2 normalisation on the output).
+Callers do not need to add any cast logic.
+
+## Notes
+
+- **No text encoder ONNX in the runtime package.** The text encoder runs only
+  at darktable-ai build time to produce `tags.json`. Free-text search would
+  require shipping the text encoder separately – deferred until that feature
+  lands in darktable.
+- **Multilingual upgrade path is clean.** A future multilingual text encoder
+  distilled to match this YFCC15M-aligned space could be added as an optional
+  sidecar package without invalidating users' indexed image embeddings.
+- **No re-indexing required for text-encoder additions.** As long as the
+  vision encoder stays unchanged, image embeddings remain valid forever.
+
+## Selection Criteria
+
+| Property | Value |
+| -------- | ----- |
+| Model license | MIT |
+| OSAID v1.0 | Open Source AI |
+| MOF | Class I (Open Science) |
+| Training data license | Creative Commons (mixed: BY, BY-SA, BY-NC, BY-ND, BY-NC-SA, BY-NC-ND, public-domain) |
+| Training data provenance | YFCC100M (Yahoo Flickr Creative Commons 100M), subset of 15M curated by Radford et al. for CLIP training. All images uploaded to Flickr by their authors under permissive licences. |
+| Training code | Open: [open_clip](https://github.com/mlfoundations/open_clip) MIT |
+| Known limitations | ResNet-101 backbone reaches modest benchmark scores compared to web-scrape-trained ViT models; the trade-off is deliberate to honour darktable's consent-based training-data criterion. |
+| Published research | [Reproducible scaling laws for contrastive language-image learning](https://arxiv.org/abs/2212.07143) |
+| Inference | Local only, no cloud dependencies |
+| Scope | Image feature extraction for tagging and similarity (no image synthesis or modification) |
+| Reproducibility | Full: `open_clip.create_model_and_transforms("RN101", pretrained="yfcc15m")` reproduces the weights; convert.py regenerates the ONNX export and tag centroids deterministically. |

--- a/models/embed-openclip-rn101-yfcc15m/convert.py
+++ b/models/embed-openclip-rn101-yfcc15m/convert.py
@@ -1,0 +1,684 @@
+"""Export OpenCLIP RN101 (YFCC15M) image encoder to ONNX and pre-compute tag embeddings.
+
+Produces:
+  model.onnx  – image encoder with baked-in CLIP normalization + L2 norm
+  tags.json   – pre-computed text embeddings for 86 hierarchical photo tags
+
+Tag vocabulary is defined in tags.md (human-readable reference).
+
+Why RN101 + YFCC15M specifically: YFCC15M is the only widely-available CLIP
+training dataset where every image was opt-in licensed by its author
+(Flickr Creative Commons). The CLIP family's other training corpora
+(LAION, WebLI, WIT, DataComp) are all web scrapes without per-image
+consent. For darktable's open-source compliance criteria this matters
+more than the ImageNet zero-shot benchmark gap.
+"""
+
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import open_clip
+
+
+# ---------------------------------------------------------------------------
+# Tag vocabulary for zero-shot tag suggestion.
+# Hierarchical names using "|" separator (darktable native).
+# Each entry is (tag, CLIP prompt). See tags.md for the human-readable list.
+# ---------------------------------------------------------------------------
+
+# Each tag carries a *list* of prompts. Encoding ensembles them: encode
+# each, average, re-normalize. This is the standard CLIP zero-shot recipe
+# (Radford et al. 2021) and substantially de-biases each centroid from
+# the quirks of any one phrasing.
+#
+# Prompts try to combine:
+#   - one direct canonical form ("a photo of X")
+#   - one or two descriptive forms with visual cues (helps high-frequency
+#     classes like cat/dog stop matching every animal photo)
+#   - context cues for setting/lighting/technique tags
+
+TAG_VOCAB = [
+    # --- genre (12) ---
+    ("genre|landscape", [
+        "a landscape photograph",
+        "a scenic landscape photo",
+        "a wide outdoor landscape view",
+        "a nature landscape image",
+    ]),
+    ("genre|portrait", [
+        "a portrait photograph",
+        "a portrait of a person",
+        "a close-up portrait photo",
+        "a head-and-shoulders portrait",
+    ]),
+    ("genre|street", [
+        "a street photography image",
+        "a candid street photo",
+        "a photo of city street life",
+        "an unposed urban scene",
+    ]),
+    ("genre|wildlife", [
+        "a wildlife photograph",
+        "a photo of a wild animal in nature",
+        "a nature wildlife image",
+    ]),
+    ("genre|macro", [
+        "a macro photograph",
+        "an extreme close-up photo",
+        "a photo of a tiny subject magnified",
+    ]),
+    ("genre|architecture", [
+        "an architecture photograph",
+        "a photo of a building's architecture",
+        "an architectural photograph of a structure",
+    ]),
+    ("genre|food", [
+        "a food photograph",
+        "a photo of a prepared meal or dish",
+        "a culinary food photo",
+    ]),
+    ("genre|sports", [
+        "a sports photograph",
+        "a photo of athletes in action",
+        "an action shot from a sporting event",
+    ]),
+    ("genre|event", [
+        "an event photograph",
+        "a photo of a wedding, party, or ceremony",
+        "a photo from a public event",
+    ]),
+    ("genre|abstract", [
+        "an abstract photograph",
+        "an abstract image with no clear subject",
+        "an abstract pattern photo",
+    ]),
+    ("genre|still life", [
+        "a still life photograph",
+        "an arranged still life photo of objects",
+        "a tabletop still life image",
+    ]),
+    ("genre|aerial", [
+        "an aerial photograph",
+        "a top-down view from above",
+        "a drone or aerial photo of the ground",
+    ]),
+    # --- subject|people (6) ---
+    ("subject|people|person", [
+        "a photograph of a person",
+        "a single individual in a photo",
+        "a person captured in an image",
+    ]),
+    ("subject|people|couple", [
+        "a photograph of a couple",
+        "two people together in a photo",
+        "a romantic couple captured in a picture",
+    ]),
+    ("subject|people|group", [
+        "a photograph of a group of people",
+        "several people together in a photo",
+        "a crowd or group photo",
+    ]),
+    ("subject|people|child", [
+        "a photograph of a child",
+        "a photo of a young kid",
+        "a picture of a school-aged child",
+    ]),
+    ("subject|people|baby", [
+        "a photograph of a baby",
+        "a photo of an infant",
+        "a picture of a newborn or toddler",
+    ]),
+    ("subject|people|elderly person", [
+        "a photograph of an elderly person",
+        "a photo of an older adult",
+        "a picture of a senior citizen",
+    ]),
+    # --- subject|animal (8) ---
+    ("subject|animal|dog", [
+        "a photograph of a dog",
+        "a close-up photo of a dog with fur and a snout",
+        "a domestic dog or puppy",
+        "a picture of a canine pet",
+    ]),
+    ("subject|animal|cat", [
+        "a photograph of a cat",
+        "a close-up photo of a cat with whiskers and pointed ears",
+        "a domestic cat or kitten",
+        "a picture of a feline pet",
+    ]),
+    ("subject|animal|bird", [
+        "a photograph of a bird",
+        "a close-up of a bird with feathers and a beak",
+        "a wild or perched bird",
+    ]),
+    ("subject|animal|horse", [
+        "a photograph of a horse",
+        "a photo of a horse with mane and hooves",
+        "an equine animal in a photo",
+    ]),
+    ("subject|animal|insect", [
+        "a photograph of an insect",
+        "a close-up of a bug with six legs and antennae",
+        "a macro photo of an insect",
+    ]),
+    ("subject|animal|fish", [
+        "a photograph of a fish",
+        "a photo of a fish underwater with fins",
+        "a picture of a marine or freshwater fish",
+    ]),
+    ("subject|animal|reptile", [
+        "a photograph of a reptile",
+        "a photo of a lizard, snake, or turtle",
+        "a cold-blooded reptile with scales",
+    ]),
+    ("subject|animal|wild animal", [
+        "a photograph of a wild animal",
+        "a photo of an animal in its natural habitat",
+        "a wildlife photo of an undomesticated creature",
+    ]),
+    # --- subject|nature (10) ---
+    ("subject|nature|flower", [
+        "a photograph of a flower",
+        "a close-up of a flower with petals",
+        "a bloom or blossom in a photo",
+    ]),
+    ("subject|nature|tree", [
+        "a photograph of a tree",
+        "a photo of a tree with leaves and branches",
+        "a single prominent tree in a photo",
+    ]),
+    ("subject|nature|mountain", [
+        "a photograph of a mountain",
+        "a photo of a mountain peak or range",
+        "a mountainous landscape",
+    ]),
+    ("subject|nature|waterfall", [
+        "a photograph of a waterfall",
+        "a photo of falling water down rocks",
+        "a cascading waterfall in nature",
+    ]),
+    ("subject|nature|river", [
+        "a photograph of a river",
+        "a photo of a flowing river or stream",
+        "a river winding through landscape",
+    ]),
+    ("subject|nature|lake", [
+        "a photograph of a lake",
+        "a photo of a calm lake or pond",
+        "a still body of water in nature",
+    ]),
+    ("subject|nature|ocean", [
+        "a photograph of the ocean",
+        "a photo of the sea with waves",
+        "an ocean or seascape image",
+    ]),
+    ("subject|nature|cloud", [
+        "a photograph of clouds",
+        "a sky filled with clouds",
+        "a cloudscape photo",
+    ]),
+    ("subject|nature|rock", [
+        "a photograph of rocks",
+        "a photo of rocky terrain or boulders",
+        "a stone or rock formation",
+    ]),
+    ("subject|nature|field", [
+        "a photograph of a field",
+        "a photo of an open grassy or agricultural field",
+        "a meadow or pasture",
+    ]),
+    # --- subject|vehicle (5) ---
+    ("subject|vehicle|car", [
+        "a photograph of a car",
+        "a photo of an automobile with wheels",
+        "a picture of a parked or driving car",
+    ]),
+    ("subject|vehicle|bicycle", [
+        "a photograph of a bicycle",
+        "a photo of a bike with two wheels",
+        "a cyclist or bicycle in a picture",
+    ]),
+    ("subject|vehicle|boat", [
+        "a photograph of a boat",
+        "a photo of a boat or ship on water",
+        "a watercraft in a picture",
+    ]),
+    ("subject|vehicle|train", [
+        "a photograph of a train",
+        "a photo of a train on tracks",
+        "a locomotive or rail vehicle",
+    ]),
+    ("subject|vehicle|airplane", [
+        "a photograph of an airplane",
+        "a photo of an aircraft in flight or on the ground",
+        "a plane with wings and engines",
+    ]),
+    # --- subject|structure (5) ---
+    ("subject|structure|building", [
+        "a photograph of a building",
+        "a photo of an architectural structure or house",
+        "an exterior shot of a building",
+    ]),
+    ("subject|structure|bridge", [
+        "a photograph of a bridge",
+        "a photo of a bridge spanning water or a gap",
+        "an architectural bridge structure",
+    ]),
+    ("subject|structure|tower", [
+        "a photograph of a tower",
+        "a photo of a tall vertical structure",
+        "a tower rising into the sky",
+    ]),
+    ("subject|structure|statue", [
+        "a photograph of a statue",
+        "a photo of a sculpted figure or monument",
+        "a sculpture in a public space",
+    ]),
+    ("subject|structure|ruin", [
+        "a photograph of a ruin",
+        "a photo of ancient or abandoned ruins",
+        "a derelict historical structure",
+    ]),
+    # --- setting (8) ---
+    ("setting|indoor", [
+        "an indoor photograph",
+        "a photo taken inside a building",
+        "an interior scene image",
+    ]),
+    ("setting|outdoor", [
+        "an outdoor photograph",
+        "a photo taken outdoors",
+        "an open-air outdoor scene",
+    ]),
+    ("setting|urban", [
+        "an urban photograph",
+        "a photo taken in a city or town",
+        "an image of urban streets and buildings",
+    ]),
+    ("setting|rural", [
+        "a rural photograph",
+        "a photo taken in the countryside",
+        "an image of rural farmland or villages",
+    ]),
+    ("setting|beach", [
+        "a photograph at a beach",
+        "a beach scene with sand and water",
+        "a coastal photograph by the sea",
+    ]),
+    ("setting|forest", [
+        "a photograph in a forest",
+        "a photo of trees in a woodland",
+        "a forest scene with dense trees",
+    ]),
+    ("setting|desert", [
+        "a photograph in a desert",
+        "a photo of a dry sandy desert landscape",
+        "a barren desert scene",
+    ]),
+    ("setting|studio", [
+        "a studio photograph",
+        "a photo with controlled studio lighting and backdrop",
+        "a posed studio image",
+    ]),
+    # --- lighting (8) ---
+    ("lighting|sunrise", [
+        "a photograph taken at sunrise",
+        "an early morning photo with the sun rising",
+        "a sunrise scene with warm sky colors",
+    ]),
+    ("lighting|sunset", [
+        "a photograph taken at sunset",
+        "an evening photo with the sun setting",
+        "a sunset sky with warm orange colors",
+    ]),
+    ("lighting|golden hour", [
+        "a photograph during golden hour",
+        "a photo with warm low-angle golden sunlight",
+        "an image bathed in golden afternoon light",
+    ]),
+    ("lighting|blue hour", [
+        "a photograph during blue hour",
+        "a twilight photo with a deep blue sky",
+        "a dusk or pre-dawn image with cool blue tones",
+    ]),
+    ("lighting|night", [
+        "a photograph taken at night",
+        "a dark nighttime image",
+        "a photo in low light after dark",
+    ]),
+    ("lighting|backlit", [
+        "a backlit photograph",
+        "a photo with the light source behind the subject",
+        "a subject lit from behind with rim light",
+    ]),
+    ("lighting|silhouette", [
+        "a silhouette photograph",
+        "a dark subject outlined against a bright background",
+        "a backlit silhouette of a figure or object",
+    ]),
+    ("lighting|low light", [
+        "a low light photograph",
+        "a dim photo with little available light",
+        "an image taken in poor lighting conditions",
+    ]),
+    # --- technique (8) ---
+    ("technique|black and white", [
+        "a black and white photograph",
+        "a monochrome grayscale image",
+        "a desaturated B&W photo",
+    ]),
+    ("technique|long exposure", [
+        "a long exposure photograph",
+        "a photo with motion blurred by a slow shutter",
+        "a smooth water or sky long exposure image",
+    ]),
+    ("technique|bokeh", [
+        "a photograph with bokeh",
+        "a photo with a blurred out-of-focus background",
+        "an image showing creamy bokeh circles",
+    ]),
+    ("technique|panorama", [
+        "a panoramic photograph",
+        "a very wide aspect ratio panorama image",
+        "a stitched panoramic scene",
+    ]),
+    ("technique|close-up", [
+        "a close-up photograph",
+        "a tight close-up of a subject",
+        "a near-distance detailed photo",
+    ]),
+    ("technique|wide angle", [
+        "a wide angle photograph",
+        "a photo taken with a wide field of view",
+        "an expansive wide-lens image",
+    ]),
+    ("technique|motion blur", [
+        "a photograph with motion blur",
+        "a photo where moving subjects are blurred",
+        "an image with intentional motion streaks",
+    ]),
+    ("technique|reflection", [
+        "a photograph with reflections",
+        "a photo showing reflective surfaces like water or glass",
+        "an image with mirrored reflections",
+    ]),
+    # --- mood (6) ---
+    ("mood|dramatic", [
+        "a dramatic photograph",
+        "an image with intense contrast and powerful mood",
+        "a striking dramatic scene",
+    ]),
+    ("mood|peaceful", [
+        "a peaceful photograph",
+        "a calm tranquil scene",
+        "a serene quiet image",
+    ]),
+    ("mood|moody", [
+        "a moody photograph",
+        "a dark atmospheric image",
+        "a brooding or melancholy photo",
+    ]),
+    ("mood|vibrant", [
+        "a vibrant photograph",
+        "a colorful saturated image",
+        "an energetic high-color photo",
+    ]),
+    ("mood|minimal", [
+        "a minimalist photograph",
+        "an image with very few elements and negative space",
+        "a clean simple minimalist composition",
+    ]),
+    ("mood|chaotic", [
+        "a chaotic photograph",
+        "a busy crowded disorderly scene",
+        "an image with many overlapping elements",
+    ]),
+    # --- weather (6) ---
+    ("weather|sunny", [
+        "a photograph in sunny weather",
+        "a bright clear-sky photo with sunshine",
+        "an image taken on a sunny day",
+    ]),
+    ("weather|cloudy", [
+        "a photograph in cloudy weather",
+        "a photo under an overcast cloudy sky",
+        "an image with a gray cloudy sky",
+    ]),
+    ("weather|rainy", [
+        "a photograph in rainy weather",
+        "a photo with visible rain or wet surfaces",
+        "a rainy day image",
+    ]),
+    ("weather|snowy", [
+        "a photograph in snowy weather",
+        "a photo with snow covering the ground",
+        "a snowy winter scene",
+    ]),
+    ("weather|foggy", [
+        "a photograph in foggy weather",
+        "a misty foggy scene with reduced visibility",
+        "an image obscured by fog or mist",
+    ]),
+    ("weather|stormy", [
+        "a photograph in stormy weather",
+        "a photo of a storm with dramatic clouds",
+        "an image during severe weather",
+    ]),
+    # --- season (4) ---
+    ("season|spring", [
+        "a photograph taken in spring",
+        "a springtime scene with fresh green growth and flowers",
+        "an image with spring bloom",
+    ]),
+    ("season|summer", [
+        "a photograph taken in summer",
+        "a summer scene with lush greenery and warm light",
+        "an image from the summer season",
+    ]),
+    ("season|autumn", [
+        "a photograph taken in autumn",
+        "an autumn scene with red, orange, and yellow leaves",
+        "a fall foliage image",
+    ]),
+    ("season|winter", [
+        "a photograph taken in winter",
+        "a winter scene with bare trees or snow",
+        "a cold-weather image from the winter season",
+    ]),
+]
+
+
+# ---------------------------------------------------------------------------
+# ONNX wrapper
+# ---------------------------------------------------------------------------
+
+class ImageEncoderOnnx(nn.Module):
+    """Wraps OpenCLIP visual encoder for ONNX export.
+
+    Bakes in CLIP-specific normalization and L2 normalization so the
+    caller only needs to provide [0, 1] float32 RGB input.
+
+    Input:  image     – float32 [B, 3, 224, 224] in [0, 1]
+    Output: embedding – float32 [B, 512] L2-normalized
+
+    With fp16=True the visual backbone runs in FP16 (weights and
+    activations) but the I/O boundary stays FP32: input cast happens
+    after mean/std subtraction; output cast happens before L2 norm.
+    """
+
+    def __init__(self, model, fp16=False):
+        super().__init__()
+        self.visual = model.visual
+        self.fp16 = fp16
+        # OpenCLIP RN101 (yfcc15m) uses the OpenAI CLIP normalisation
+        # constants – same as all other OpenCLIP variants
+        self.register_buffer(
+            "mean",
+            torch.tensor([0.48145466, 0.4578275, 0.40821073]).view(1, 3, 1, 1),
+        )
+        self.register_buffer(
+            "std",
+            torch.tensor([0.26862954, 0.26130258, 0.27577711]).view(1, 3, 1, 1),
+        )
+        if fp16:
+            # cast the backbone (weights + buffers) to FP16. Mean/std
+            # buffers stay FP32 so the input subtraction is done in FP32
+            # before the downcast – avoids one round of precision loss.
+            self.visual = self.visual.half()
+
+    @torch.no_grad()
+    def forward(self, image):
+        x = (image - self.mean) / self.std
+        if self.fp16:
+            x = x.half()
+        features = self.visual(x)
+        if self.fp16:
+            features = features.float()
+        features = F.normalize(features, dim=-1)
+        return features
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def export_image_encoder(model, output_path, opset, fp16=False):
+    """Export image encoder to ONNX.
+
+    For FP16 we cast the visual backbone to half() in PyTorch and let
+    torch.onnx.export produce an FP16-internals graph directly. This is
+    much faster than post-converting an FP32 ONNX file with
+    onnxconverter-common (which scales badly on 130M-param graphs).
+    The graph's IO stays FP32 because the casts happen inside the wrapper.
+    """
+    encoder = ImageEncoderOnnx(model, fp16=fp16)
+    encoder.eval()
+
+    # fixed seed so the ORT-vs-PyTorch diff print is reproducible across
+    # runs and meaningful as a regression signal
+    torch.manual_seed(0)
+    dummy = torch.randn(1, 3, 224, 224)
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    precision = "FP16" if fp16 else "FP32"
+    print(f"Exporting image encoder ({precision} internals) to {output_path}...")
+    # Legacy tracer rather than dynamo: ResNet has no attention ops to
+    # confuse the tracer, and dynamo's BatchNorm handling crashes on
+    # _native_batch_norm_legit_no_training (returns a tuple that the
+    # ONNX type-inference path mishandles).
+    torch.onnx.export(
+        encoder,
+        (dummy,),
+        output_path,
+        export_params=True,
+        opset_version=opset,
+        do_constant_folding=True,
+        input_names=['image'],
+        output_names=['embedding'],
+        dynamic_axes={
+            'image':     {0: 'batch'},
+            'embedding': {0: 'batch'},
+        },
+        verbose=False,
+    )
+
+    import onnx
+    onnx_model = onnx.load(output_path)
+    onnx.checker.check_model(onnx_model)
+    print("ONNX checker passed.")
+
+    # verify ONNX output matches PyTorch
+    import onnxruntime as ort
+    session = ort.InferenceSession(output_path, providers=["CPUExecutionProvider"])
+    input_name = session.get_inputs()[0].name
+    ort_out = session.run(None, {input_name: dummy.numpy()})[0]
+    ref_out = encoder(dummy).numpy()
+    diff = np.abs(ort_out - ref_out).max()
+    print(f"ONNX vs PyTorch max diff ({precision}): {diff:.6f}")
+    print(f"Output shape: {ort_out.shape}, norm: {np.linalg.norm(ort_out, axis=-1)}")
+
+
+def generate_tags(model, tokenizer, output_path):
+    """Pre-compute text embeddings for photo tags using prompt ensembling.
+
+    For each tag:
+      1. encode all of its prompt variants
+      2. average the L2-normalized embeddings
+      3. re-normalize the average to unit length
+
+    No centering — centering shifts the cosine similarity range so much
+    that the threshold becomes meaningless, and the top-K filter on the
+    consumer side is a better way to limit over-eager tags.
+    """
+    tags = [tag for tag, _ in TAG_VOCAB]
+
+    centroids = []
+    with torch.no_grad():
+        for _tag, prompts in TAG_VOCAB:
+            tokens = tokenizer(prompts)
+            feats = model.encode_text(tokens)
+            feats = F.normalize(feats, dim=-1)        # normalize each prompt
+            centroid = feats.mean(dim=0)               # average
+            centroid = F.normalize(centroid, dim=-1)   # renormalize
+            centroids.append(centroid.cpu().numpy())
+
+    embeddings = [c.tolist() for c in centroids]
+
+    data = {"tags": tags, "embeddings": embeddings}
+    with open(output_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+    print(f"Generated {len(tags)} tag centroids → {output_path}")
+    print(f"  (ensembled from {sum(len(p) for _, p in TAG_VOCAB)} prompts)")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def convert(output, tags_output, opset=20, fp16=False):
+    """Entry point for programmatic conversion."""
+    os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
+
+    print("Loading OpenCLIP RN101 (yfcc15m)...")
+    # YFCC15M weights were trained with QuickGELU activation; the open_clip
+    # factory defaults to standard GELU and only warns about the mismatch
+    # – but the mismatch produces subtly wrong outputs. Force it on.
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        "RN101", pretrained="yfcc15m", force_quick_gelu=True
+    )
+    model.eval()
+    for param in model.parameters():
+        param.requires_grad = False
+
+    tokenizer = open_clip.get_tokenizer("RN101")
+
+    export_image_encoder(model, output, opset, fp16=fp16)
+    generate_tags(model, tokenizer, tags_output)
+
+    print("Done!")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export OpenCLIP RN101 (YFCC15M) image encoder to ONNX"
+    )
+    parser.add_argument("--output", required=True, help="Output ONNX path")
+    parser.add_argument("--tags-output", required=True, help="Output tags.json path")
+    parser.add_argument("--opset", type=int, default=20, help="ONNX opset version")
+    parser.add_argument("--fp16", action="store_true",
+                        help="convert weights to FP16 after export (default: FP32)")
+    args = parser.parse_args()
+
+    convert(args.output, args.tags_output, args.opset, fp16=args.fp16)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/embed-openclip-rn101-yfcc15m/demo.py
+++ b/models/embed-openclip-rn101-yfcc15m/demo.py
@@ -1,0 +1,139 @@
+"""Demo: compute image embedding and show top-5 zero-shot tags.
+
+Saves a PNG with the original image and top-5 tag predictions overlaid.
+"""
+
+import argparse
+import json
+import os
+import time
+
+import numpy as np
+import onnxruntime as ort
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+IMAGE_SIZE = 224
+
+
+def preprocess(image):
+    """Resize shortest edge to 224, center crop, normalize to [0, 1] BCHW."""
+    w, h = image.size
+    scale = IMAGE_SIZE / min(w, h)
+    new_w, new_h = int(w * scale + 0.5), int(h * scale + 0.5)
+    image = image.resize((new_w, new_h), Image.LANCZOS)
+
+    left = (new_w - IMAGE_SIZE) // 2
+    top = (new_h - IMAGE_SIZE) // 2
+    image = image.crop((left, top, left + IMAGE_SIZE, top + IMAGE_SIZE))
+
+    arr = np.array(image).astype(np.float32) / 255.0
+    arr = arr.transpose(2, 0, 1)[np.newaxis]  # BCHW
+    return arr
+
+
+def draw_tags(image, tags_scores):
+    """Draw top tags on the image and return the annotated image."""
+    draw = ImageDraw.Draw(image)
+    w, h = image.size
+    font_size = max(16, min(w, h) // 25)
+    pad = max(4, font_size // 4)
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", font_size)
+    except (OSError, IOError):
+        try:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size)
+        except (OSError, IOError):
+            font = ImageFont.load_default()
+
+    y = pad * 2
+    for tag, score in tags_scores:
+        text = f"{tag}: {score:.2f}"
+        bbox = draw.textbbox((0, 0), text, font=font)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        draw.rectangle(
+            [pad, y - pad // 2, pad * 2 + tw, y + th + pad // 2],
+            fill=(0, 0, 0, 180),
+        )
+        draw.text((pad + pad // 2, y), text, fill=(255, 255, 255), font=font)
+        y += th + pad * 2
+
+    return image
+
+
+def run_inference(model_path, image_path, output_path):
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+
+    # Load tags
+    model_dir = os.path.dirname(model_path)
+    tags_path = os.path.join(model_dir, "tags.json")
+    if not os.path.isfile(tags_path):
+        print(f"Warning: tags.json not found at {tags_path}")
+        tags, tag_embeddings = [], None
+    else:
+        with open(tags_path) as f:
+            data = json.load(f)
+        tags = data["tags"]
+        tag_embeddings = np.array(data["embeddings"], dtype=np.float32)
+
+    t0 = time.perf_counter()
+
+    # Load model
+    session = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+    t_load = time.perf_counter()
+
+    # Load and preprocess image
+    image = Image.open(image_path)
+    image = ImageOps.exif_transpose(image)
+    image = image.convert("RGB")
+    orig_w, orig_h = image.size
+    input_tensor = preprocess(image)
+    t_pre = time.perf_counter()
+
+    # Run inference
+    (embedding,) = session.run(None, {"image": input_tensor})
+    t_inf = time.perf_counter()
+
+    print(f"  Image: {orig_w}x{orig_h}")
+    print(f"  Embedding: shape={embedding.shape}, norm={np.linalg.norm(embedding):.4f}")
+    print(f"  Load: {t_load - t0:.3f}s  Preprocess: {t_pre - t_load:.3f}s  Inference: {t_inf - t_pre:.3f}s")
+
+    # Zero-shot classification
+    if tag_embeddings is not None:
+        scores = (embedding @ tag_embeddings.T)[0]  # dot product = cosine sim
+        top_idx = np.argsort(scores)[::-1][:5]
+        tags_scores = [(tags[i], float(scores[i])) for i in top_idx]
+
+        print("  Top-5 tags:")
+        for tag, score in tags_scores:
+            print(f"    {score:.3f}  {tag}")
+
+        # Save annotated image
+        annotated = image.copy().convert("RGBA")
+        overlay = Image.new("RGBA", annotated.size, (0, 0, 0, 0))
+        annotated = draw_tags(overlay, tags_scores)
+        result = Image.alpha_composite(image.convert("RGBA"), annotated)
+        result.convert("RGB").save(output_path)
+    else:
+        image.save(output_path)
+
+    print(f"  Saved: {output_path}")
+    print(f"  Total: {time.perf_counter() - t0:.3f}s")
+
+
+def demo(model, image, output, **kwargs):
+    """Entry point for programmatic demo."""
+    run_inference(model, image, output)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OpenCLIP embedding demo")
+    parser.add_argument("--model", required=True, help="Path to model.onnx")
+    parser.add_argument("--image", required=True, help="Input image path")
+    parser.add_argument("--output", required=True, help="Output PNG path")
+    args = parser.parse_args()
+
+    demo(args.model, args.image, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/embed-openclip-rn101-yfcc15m/model.yaml
+++ b/models/embed-openclip-rn101-yfcc15m/model.yaml
@@ -1,0 +1,38 @@
+id: embed-openclip-rn101-yfcc15m
+name: "embed openclip rn101 yfcc15m"
+description: "OpenCLIP RN101 for tag suggestions and image-similarity search; trained on Flickr Creative Commons photos (YFCC15M)"
+task: embed
+version: "0.1"
+arch: openclip-rn101
+type: single
+dep_group: openclip
+
+attributes:
+  # preprocessing — read by darktable's embedding pipeline
+  input_sizes: [224]
+  color_space: rgb
+  input_scale: 0.00392156862745098   # 1/255: uint8 → [0, 1]
+  # CLIP mean/std and the L2 norm are baked into the ONNX graph
+  # (see convert.py BiRefNetOnnx-style wrapper), so declare them as no-ops
+  norm_mean: [0.0, 0.0, 0.0]
+  norm_std:  [1.0, 1.0, 1.0]
+  output_l2_normalized: true
+
+model_card:
+  long_description: "OpenCLIP RN101. Powers tag suggestions and similar-image search. Trained on 15 million Flickr photos shared under Creative Commons licences – the only widely-available CLIP dataset built from author-consented images"
+  scope: "image tagging and similarity search"
+  author: "OpenCLIP (mlfoundations); YFCC15M curation: Thomee et al."
+  source: "https://github.com/mlfoundations/open_clip"
+  paper: "https://arxiv.org/abs/2212.07143"
+  license: "MIT"
+  training_data: "YFCC15M – 15M Flickr photos with Creative Commons licences, curated by Radford et al. for CLIP training"
+  training_data_license: "Creative Commons (mixed: BY, BY-SA, BY-NC, BY-ND, BY-NC-SA, BY-NC-ND, public-domain)"
+  notes: "English-only. The vision encoder is photo-domain-aligned, so quality on photo libraries is closer to larger web-scraped models than benchmark scores suggest"
+
+convert:
+  - script: convert.py
+    args:
+      output: "{output}/model.onnx"
+      tags_output: "{output}/tags.json"
+      opset: 20
+      fp16: true

--- a/models/embed-openclip-rn101-yfcc15m/tags.md
+++ b/models/embed-openclip-rn101-yfcc15m/tags.md
@@ -1,0 +1,152 @@
+# Default tag vocabulary
+
+86 hierarchical tags for zero-shot image classification.
+Tags use `|` as hierarchy separator, matching darktable's tag system.
+
+## genre (12)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `genre\|landscape` | landscape photography |
+| `genre\|portrait` | portrait photography |
+| `genre\|street` | street photography |
+| `genre\|wildlife` | wildlife photography |
+| `genre\|macro` | macro photography |
+| `genre\|architecture` | architecture photography |
+| `genre\|food` | food photography |
+| `genre\|sports` | sports photography |
+| `genre\|event` | event photography |
+| `genre\|abstract` | abstract photography |
+| `genre\|still life` | still life photography |
+| `genre\|aerial` | aerial photography |
+
+## subject (34)
+
+### subject|people (6)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `subject\|people\|person` | a photo of a person |
+| `subject\|people\|couple` | a photo of a couple |
+| `subject\|people\|group` | a photo of a group of people |
+| `subject\|people\|child` | a photo of a child |
+| `subject\|people\|baby` | a photo of a baby |
+| `subject\|people\|elderly person` | a photo of an elderly person |
+
+### subject|animal (8)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `subject\|animal\|dog` | a photo of a dog |
+| `subject\|animal\|cat` | a photo of a cat |
+| `subject\|animal\|bird` | a photo of a bird |
+| `subject\|animal\|horse` | a photo of a horse |
+| `subject\|animal\|insect` | a photo of an insect |
+| `subject\|animal\|fish` | a photo of a fish |
+| `subject\|animal\|reptile` | a photo of a reptile |
+| `subject\|animal\|wild animal` | a photo of a wild animal |
+
+### subject|nature (10)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `subject\|nature\|flower` | a photo of a flower |
+| `subject\|nature\|tree` | a photo of a tree |
+| `subject\|nature\|mountain` | a photo of a mountain |
+| `subject\|nature\|waterfall` | a photo of a waterfall |
+| `subject\|nature\|river` | a photo of a river |
+| `subject\|nature\|lake` | a photo of a lake |
+| `subject\|nature\|ocean` | a photo of the ocean |
+| `subject\|nature\|cloud` | a photo of clouds |
+| `subject\|nature\|rock` | a photo of rocks |
+| `subject\|nature\|field` | a photo of a field |
+
+### subject|vehicle (5)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `subject\|vehicle\|car` | a photo of a car |
+| `subject\|vehicle\|bicycle` | a photo of a bicycle |
+| `subject\|vehicle\|boat` | a photo of a boat |
+| `subject\|vehicle\|train` | a photo of a train |
+| `subject\|vehicle\|airplane` | a photo of an airplane |
+
+### subject|structure (5)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `subject\|structure\|building` | a photo of a building |
+| `subject\|structure\|bridge` | a photo of a bridge |
+| `subject\|structure\|tower` | a photo of a tower |
+| `subject\|structure\|statue` | a photo of a statue |
+| `subject\|structure\|ruin` | a photo of a ruin |
+
+## setting (8)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `setting\|indoor` | an indoor photograph |
+| `setting\|outdoor` | an outdoor photograph |
+| `setting\|urban` | a photo taken in an urban setting |
+| `setting\|rural` | a photo taken in a rural setting |
+| `setting\|beach` | a photo taken at a beach |
+| `setting\|forest` | a photo taken in a forest |
+| `setting\|desert` | a photo taken in a desert |
+| `setting\|studio` | a studio photograph |
+
+## lighting (8)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `lighting\|sunrise` | a photo taken at sunrise |
+| `lighting\|sunset` | a photo taken at sunset |
+| `lighting\|golden hour` | a photo taken during golden hour |
+| `lighting\|blue hour` | a photo taken during blue hour |
+| `lighting\|night` | a photo taken at night |
+| `lighting\|backlit` | a backlit photograph |
+| `lighting\|silhouette` | a silhouette photograph |
+| `lighting\|low light` | a low light photograph |
+
+## technique (8)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `technique\|black and white` | a black and white photograph |
+| `technique\|long exposure` | a long exposure photograph |
+| `technique\|bokeh` | a photograph with bokeh |
+| `technique\|panorama` | a panoramic photograph |
+| `technique\|close-up` | a close-up photograph |
+| `technique\|wide angle` | a wide angle photograph |
+| `technique\|motion blur` | a photograph with motion blur |
+| `technique\|reflection` | a photograph with reflections |
+
+## mood (6)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `mood\|dramatic` | a dramatic photograph |
+| `mood\|peaceful` | a peaceful photograph |
+| `mood\|moody` | a moody photograph |
+| `mood\|vibrant` | a vibrant photograph |
+| `mood\|minimal` | a minimalist photograph |
+| `mood\|chaotic` | a chaotic photograph |
+
+## weather (6)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `weather\|sunny` | a photo taken in sunny weather |
+| `weather\|cloudy` | a photo taken in cloudy weather |
+| `weather\|rainy` | a photo taken in rainy weather |
+| `weather\|snowy` | a photo taken in snowy weather |
+| `weather\|foggy` | a photo taken in foggy weather |
+| `weather\|stormy` | a photo taken in stormy weather |
+
+## season (4)
+
+| Tag | CLIP prompt |
+|-----|-------------|
+| `season\|spring` | a photo taken in spring |
+| `season\|summer` | a photo taken in summer |
+| `season\|autumn` | a photo taken in autumn |
+| `season\|winter` | a photo taken in winter |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ sam21 = [
     "hydra-core>=1.3.2",
     "iopath>=0.1.10",
 ]
+openclip = [
+    {include-group = "core"},
+    "open_clip_torch",
+]
 all-models = [
     {include-group = "nafnet"},
     {include-group = "nind"},
@@ -85,6 +89,7 @@ all-models = [
     {include-group = "bsrgan"},
     {include-group = "realplksr"},
     {include-group = "sam21"},
+    {include-group = "openclip"},
 ]
 eval = [
     "numpy<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -77,6 +86,19 @@ name = "antlr4-python3-runtime"
 version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -246,6 +268,7 @@ all-models = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
+    { name = "open-clip-torch" },
     { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
@@ -312,6 +335,16 @@ nind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
+    { name = "opencv-python-headless" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+openclip = [
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "onnxruntime" },
+    { name = "onnxsim" },
+    { name = "open-clip-torch" },
     { name = "opencv-python-headless" },
     { name = "torch" },
     { name = "torchvision" },
@@ -392,6 +425,7 @@ all-models = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
+    { name = "open-clip-torch" },
     { name = "opencv-python-headless" },
     { name = "ptflops" },
     { name = "pytorch-msssim" },
@@ -459,6 +493,16 @@ nind = [
     { name = "onnxconverter-common" },
     { name = "onnxruntime" },
     { name = "onnxsim" },
+    { name = "opencv-python-headless" },
+    { name = "torch", specifier = ">=2.2.0,<2.7" },
+    { name = "torchvision", specifier = ">=0.17.0,<0.22" },
+]
+openclip = [
+    { name = "numpy", specifier = "<2.0" },
+    { name = "onnx", specifier = ">=1.10.0" },
+    { name = "onnxruntime" },
+    { name = "onnxsim" },
+    { name = "open-clip-torch" },
     { name = "opencv-python-headless" },
     { name = "torch", specifier = ">=2.2.0,<2.7" },
     { name = "torchvision", specifier = ">=0.17.0,<0.22" },
@@ -587,6 +631,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
 name = "future"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -624,6 +680,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
     { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
     { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -1172,6 +1301,25 @@ wheels = [
 ]
 
 [[package]]
+name = "open-clip-torch"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ftfy" },
+    { name = "huggingface-hub" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/1f/2bc9795047fa2c1ad2567ef78ce6dfc9a7b763fa534acee09a94da2a5b8f/open_clip_torch-3.3.0.tar.gz", hash = "sha256:904b1a9f909df8281bb3de60ab95491cd2994a509177ea4f9d6292a84fe24d6d", size = 1503380, upload-time = "2026-02-27T00:32:46.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/b5/41c315ccd94ca332ead3e832e83eee343ab245005c3e43d9d3e75eae34eb/open_clip_torch-3.3.0-py3-none-any.whl", hash = "sha256:c549ad5ed6bfc119cc11105033c0a2b9d7a2a4afeb40a58a09aab3da1a0043ce", size = 1547268, upload-time = "2026-02-27T00:32:44.902Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
@@ -1467,9 +1615,35 @@ version = "2026.2.28"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184, upload-time = "2026-02-28T02:19:42.792Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/db/8cbfd0ba3f302f2d09dd0019a9fcab74b63fee77a76c937d0e33161fb8c1/regex-2026.2.28-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e621fb7c8dc147419b28e1702f58a0177ff8308a76fa295c71f3e7827849f5d9", size = 488462, upload-time = "2026-02-28T02:16:22.616Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ccc22c52802223f2368731964ddd117799e1390ffc39dbb31634a83022ee/regex-2026.2.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d5bef2031cbf38757a0b0bc4298bb4824b6332d28edc16b39247228fbdbad97", size = 290774, upload-time = "2026-02-28T02:16:23.993Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b9/6796b3bf3101e64117201aaa3a5a030ec677ecf34b3cd6141b5d5c6c67d5/regex-2026.2.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcb399ed84eabf4282587ba151f2732ad8168e66f1d3f85b1d038868fe547703", size = 288724, upload-time = "2026-02-28T02:16:25.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/02/291c0ae3f3a10cea941d0f5366da1843d8d1fa8a25b0671e20a0e454bb38/regex-2026.2.28-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c1b34dfa72f826f535b20712afa9bb3ba580020e834f3c69866c5bddbf10098", size = 791924, upload-time = "2026-02-28T02:16:26.863Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/57/f0235cc520d9672742196c5c15098f8f703f2758d48d5a7465a56333e496/regex-2026.2.28-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:851fa70df44325e1e4cdb79c5e676e91a78147b1b543db2aec8734d2add30ec2", size = 860095, upload-time = "2026-02-28T02:16:28.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/393c94cbedda79a0f5f2435ebd01644aba0b338d327eb24b4aa5b8d6c07f/regex-2026.2.28-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:516604edd17b1c2c3e579cf4e9b25a53bf8fa6e7cedddf1127804d3e0140ca64", size = 906583, upload-time = "2026-02-28T02:16:30.977Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/73/a72820f47ca5abf2b5d911d0407ba5178fc52cf9780191ed3a54f5f419a2/regex-2026.2.28-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7ce83654d1ab701cb619285a18a8e5a889c1216d746ddc710c914ca5fd71022", size = 800234, upload-time = "2026-02-28T02:16:32.55Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b3/6e6a4b7b31fa998c4cf159a12cbeaf356386fbd1a8be743b1e80a3da51e4/regex-2026.2.28-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2791948f7c70bb9335a9102df45e93d428f4b8128020d85920223925d73b9e1", size = 772803, upload-time = "2026-02-28T02:16:34.029Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e7/5da0280c765d5a92af5e1cd324b3fe8464303189cbaa449de9a71910e273/regex-2026.2.28-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a83cc26aa2acda6b8b9dfe748cf9e84cbd390c424a1de34fdcef58961a297a", size = 781117, upload-time = "2026-02-28T02:16:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/76/39/0b8d7efb256ae34e1b8157acc1afd8758048a1cf0196e1aec2e71fd99f4b/regex-2026.2.28-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ec6f5674c5dc836994f50f1186dd1fafde4be0666aae201ae2fcc3d29d8adf27", size = 854224, upload-time = "2026-02-28T02:16:38.119Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ff/a96d483ebe8fe6d1c67907729202313895d8de8495569ec319c6f29d0438/regex-2026.2.28-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:50c2fc924749543e0eacc93ada6aeeb3ea5f6715825624baa0dccaec771668ae", size = 761898, upload-time = "2026-02-28T02:16:40.333Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bd/d4f2e75cb4a54b484e796017e37c0d09d8a0a837de43d17e238adf163f4e/regex-2026.2.28-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ba55c50f408fb5c346a3a02d2ce0ebc839784e24f7c9684fde328ff063c3cdea", size = 844832, upload-time = "2026-02-28T02:16:41.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/428a135cf5e15e4e11d1e696eb2bf968362f8ea8a5f237122e96bc2ae950/regex-2026.2.28-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:edb1b1b3a5576c56f08ac46f108c40333f222ebfd5cf63afdfa3aab0791ebe5b", size = 788347, upload-time = "2026-02-28T02:16:43.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/59/68691428851cf9c9c3707217ab1d9b47cfeec9d153a49919e6c368b9e926/regex-2026.2.28-cp311-cp311-win32.whl", hash = "sha256:948c12ef30ecedb128903c2c2678b339746eb7c689c5c21957c4a23950c96d15", size = 266033, upload-time = "2026-02-28T02:16:45.094Z" },
     { url = "https://files.pythonhosted.org/packages/42/8b/1483de1c57024e89296cbcceb9cccb3f625d416ddb46e570be185c9b05a9/regex-2026.2.28-cp311-cp311-win_amd64.whl", hash = "sha256:fd63453f10d29097cc3dc62d070746523973fb5aa1c66d25f8558bebd47fed61", size = 277978, upload-time = "2026-02-28T02:16:46.75Z" },
     { url = "https://files.pythonhosted.org/packages/a4/36/abec45dc6e7252e3dbc797120496e43bb5730a7abf0d9cb69340696a2f2d/regex-2026.2.28-cp311-cp311-win_arm64.whl", hash = "sha256:00f2b8d9615aa165fdff0a13f1a92049bfad555ee91e20d246a51aa0b556c60a", size = 270340, upload-time = "2026-02-28T02:16:48.626Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/9061b03cf0fc4b5fa2c3984cbbaed54324377e440a5c5a29d29a72518d62/regex-2026.2.28-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fcf26c3c6d0da98fada8ae4ef0aa1c3405a431c0a77eb17306d38a89b02adcd7", size = 489574, upload-time = "2026-02-28T02:16:50.455Z" },
+    { url = "https://files.pythonhosted.org/packages/77/83/0c8a5623a233015595e3da499c5a1c13720ac63c107897a6037bb97af248/regex-2026.2.28-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02473c954af35dd2defeb07e44182f5705b30ea3f351a7cbffa9177beb14da5d", size = 291426, upload-time = "2026-02-28T02:16:52.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/06/3ef1ac6910dc3295ebd71b1f9bfa737e82cfead211a18b319d45f85ddd09/regex-2026.2.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b65d33a17101569f86d9c5966a8b1d7fbf8afdda5a8aa219301b0a80f58cf7d", size = 289200, upload-time = "2026-02-28T02:16:54.08Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c9/8cc8d850b35ab5650ff6756a1cb85286e2000b66c97520b29c1587455344/regex-2026.2.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71dcecaa113eebcc96622c17692672c2d104b1d71ddf7adeda90da7ddeb26fc", size = 796765, upload-time = "2026-02-28T02:16:55.905Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5d/57702597627fc23278ebf36fbb497ac91c0ce7fec89ac6c81e420ca3e38c/regex-2026.2.28-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:481df4623fa4969c8b11f3433ed7d5e3dc9cec0f008356c3212b3933fb77e3d8", size = 863093, upload-time = "2026-02-28T02:16:58.094Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/f3ecad537ca2811b4d26b54ca848cf70e04fcfc138667c146a9f3157779c/regex-2026.2.28-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64e7c6ad614573e0640f271e811a408d79a9e1fe62a46adb602f598df42a818d", size = 909455, upload-time = "2026-02-28T02:17:00.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/40/bb226f203caa22c1043c1ca79b36340156eca0f6a6742b46c3bb222a3a57/regex-2026.2.28-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b08a06976ff4fb0d83077022fde3eca06c55432bb997d8c0495b9a4e9872f4", size = 802037, upload-time = "2026-02-28T02:17:02.842Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7c/c6d91d8911ac6803b45ca968e8e500c46934e58c0903cbc6d760ee817a0a/regex-2026.2.28-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:864cdd1a2ef5716b0ab468af40139e62ede1b3a53386b375ec0786bb6783fc05", size = 775113, upload-time = "2026-02-28T02:17:04.506Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/4a9368d168d47abd4158580b8c848709667b1cd293ff0c0c277279543bd0/regex-2026.2.28-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:511f7419f7afab475fd4d639d4aedfc54205bcb0800066753ef68a59f0f330b5", size = 784194, upload-time = "2026-02-28T02:17:06.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bf/2c72ab5d8b7be462cb1651b5cc333da1d0068740342f350fcca3bca31947/regex-2026.2.28-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b42f7466e32bf15a961cf09f35fa6323cc72e64d3d2c990b10de1274a5da0a59", size = 856846, upload-time = "2026-02-28T02:17:09.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f4/6b65c979bb6d09f51bb2d2a7bc85de73c01ec73335d7ddd202dcb8cd1c8f/regex-2026.2.28-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8710d61737b0c0ce6836b1da7109f20d495e49b3809f30e27e9560be67a257bf", size = 763516, upload-time = "2026-02-28T02:17:11.004Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/29ea5e27400ee86d2cc2b4e80aa059df04eaf78b4f0c18576ae077aeff68/regex-2026.2.28-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4390c365fd2d45278f45afd4673cb90f7285f5701607e3ad4274df08e36140ae", size = 849278, upload-time = "2026-02-28T02:17:12.693Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/3233d03b5f865111cd517e1c95ee8b43e8b428d61fa73764a80c9bb6f537/regex-2026.2.28-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb3b1db8ff6c7b8bf838ab05583ea15230cb2f678e569ab0e3a24d1e8320940b", size = 790068, upload-time = "2026-02-28T02:17:14.9Z" },
     { url = "https://files.pythonhosted.org/packages/76/92/abc706c1fb03b4580a09645b206a3fc032f5a9f457bc1a8038ac555658ab/regex-2026.2.28-cp312-cp312-win32.whl", hash = "sha256:f8ed9a5d4612df9d4de15878f0bc6aa7a268afbe5af21a3fdd97fa19516e978c", size = 266416, upload-time = "2026-02-28T02:17:17.15Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/2a6f7dff190e5fa9df9fb4acf2fdf17a1aa0f7f54596cba8de608db56b3a/regex-2026.2.28-cp312-cp312-win_amd64.whl", hash = "sha256:01d65fd24206c8e1e97e2e31b286c59009636c022eb5d003f52760b0f42155d4", size = 277297, upload-time = "2026-02-28T02:17:18.723Z" },
     { url = "https://files.pythonhosted.org/packages/b7/f0/58a2484851fadf284458fdbd728f580d55c1abac059ae9f048c63b92f427/regex-2026.2.28-cp312-cp312-win_arm64.whl", hash = "sha256:c0b5ccbb8ffb433939d248707d4a8b31993cb76ab1a0187ca886bf50e96df952", size = 270408, upload-time = "2026-02-28T02:17:20.328Z" },
@@ -1597,6 +1771,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1753,6 +1936,22 @@ wheels = [
 ]
 
 [[package]]
+name = "timm"
+version = "1.0.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/2e/26bab7686ff4aed48f8f5f6c23e2aa37b7a37ddd9effe3aa61e908fd518f/timm-1.0.27-py3-none-any.whl", hash = "sha256:5ff07c9ddf53cbada88eab1c93ff175c64cab683b5a2fddf863bcee985926f89", size = 2589280, upload-time = "2026-05-08T19:38:35.034Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1834,6 +2033,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1861,6 +2075,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds `embed-openclip-rn101-yfcc15m` – a ResNet-101 image embedder for tag suggestion and image-similarity search.

Why this one and not a stronger CLIP variant: every other CLIP training corpus (LAION, WIT-400M, DataComp, MetaCLIP, WebLI) is a web scrape with no per-image consent. YFCC15M is 15M Flickr photos uploaded under Creative Commons – the one option that meets the project's consent-based training-data criterion. The cost is a lower benchmark score (~31% ImageNet zero-shot vs ~67% for LAION ViT-B-32), but in actual photo-library use the gap is much smaller than that number suggests.

Ships `model.onnx` (60 MB FP16, mean/std + L2 norm baked in) plus `tags.json` – 86 precomputed centroids for cold-start tag suggestions before users have enough data of their own. Text encoder runs at convert time only, not shipped.